### PR TITLE
Fix build against system library.

### DIFF
--- a/argon2.cabal
+++ b/argon2.cabal
@@ -72,7 +72,7 @@ library
 
   if flag(use-system-library)
     cpp-options: -DUSE_SYSTEM_ARGON2=1
-    pkgconfig-depends: argon2
+    pkgconfig-depends: libargon2
   else
     cpp-options: -DUSE_SYSTEM_ARGON2=0
     c-sources: phc-winner-argon2/src/argon2.c


### PR DESCRIPTION
The pkg-config file is named libargon2, not argon2.