### PR TITLE
Make tests run in a few seconds

### DIFF
--- a/src-tests/Tests.hs
+++ b/src-tests/Tests.hs
@@ -5,6 +5,7 @@ import qualified Crypto.Argon2.FFI     as FFI
 import           Data.Bits             (shiftL)
 import qualified Data.ByteString       as BS
 import           Data.Ix
+import           Data.Word             (Word32)
 import           Test.QuickCheck
 import           Test.Tasty
 import           Test.Tasty.HUnit
@@ -19,14 +20,15 @@ arbitraryVersion = arbitraryBoundedEnum
 arbitraryHashOptions :: Gen HashOptions
 arbitraryHashOptions =
   do p <- arbitraryWithin 1 4
-     HashOptions <$> arbitraryWithin FFI.ARGON2_MIN_TIME (min FFI.ARGON2_MAX_TIME 65536)
+     HashOptions <$> arbitraryWithin FFI.ARGON2_MIN_TIME (min FFI.ARGON2_MAX_TIME (2 ^ 8))
                  <*> arbitraryWithin (FFI.ARGON2_MIN_MEMORY*p) (FFI.ARGON2_MIN_MEMORY*p*4)  -- arbitraryWithin (max (max FFI.ARGON2_MIN_MEMORY (8 * p)) (shiftL p 3)) (min FFI.ARGON2_MAX_MEMORY 512)
                  <*> pure p
                  <*> arbitraryVariant
                  <*> arbitraryVersion
                  <*> arbitraryWithin FFI.ARGON2_MIN_OUTLEN (min FFI.ARGON2_MAX_OUTLEN 65536)
-
-arbitraryWithin lower upper = arbitrary `suchThat` (inRange (lower,upper))
+  where
+    arbitraryWithin :: Word32 -> Word32 -> Gen Word32
+    arbitraryWithin = curry chooseEnum
 
 arbitraryBytes :: Gen BS.ByteString
 arbitraryBytes = BS.pack <$> arbitrary


### PR DESCRIPTION
```
Running 1 test suites...
Test suite tests: RUNNING...
Tests
  KATs
    argon2 README
      hashEncoded:      OK (0.07s)
      verifyEncoded:    OK (0.07s)
      verifyEncoded 2:  OK (0.07s)
      verifyEncoded 3:  OK (0.07s)
      verifyEncoded 4:  OK (0.07s)
      verifyEncoded 5:  OK
      verifyEncoded 6:  OK
      verifyEncoded 7:  OK
      hash:             OK (0.07s)
  Properties
    Round trip:         OK (5.86s)
      +++ OK, passed 100 tests.
    Unencoded hashing:  OK (2.86s)
      +++ OK, passed 100 tests.
    defaultHashOptions: OK (1.28s)
      +++ OK, passed 100 tests.

All 12 tests passed (10.42s)
Test suite tests: PASS
```